### PR TITLE
Syntax: fix instruction shorthand and add addressing mode

### DIFF
--- a/syntaxes/qcpu.tmLanguage.json
+++ b/syntaxes/qcpu.tmLanguage.json
@@ -30,11 +30,11 @@
 			"name": "comment"
 		},
 		"assembly": {
-			"match": "\\b(?:ADD|AND|AST|CND|CPL|CPN|CPS|DSS|DEC|DLS|ENT|IMM|IMP|INC|IOR|JMP|MDA|MLD|MMA|MSA|MST|NEG|NOP|NTA|PCM|PLD|POI|PPL|PPS|PST|RSH|RST|SPL|SUB|XOR)\\b",
+			"match": "\\b(?:ADD|AND|AST|CND|CPL|CPN|CPS|DEC|DLS|DSS|ENT|IMM|IMP|INC|IOR|JMP|MDA|MLD|MMA|MSA|MST|NEG|NOP|NTA|PCM|PLD|POI|PPL|PPS|PST|RSH|RST|SPL|SUB|XOR)\\b",
 			"name": "keyword"
 		},
 		"label": {
-			"match": "\\.&?([\\w.@]+)\\b[:!+-\*]?",
+			"match": "\\.&?([\\w.@]+)\\b[:!+-*]?",
 			"captures": {
 				"0": { "name": "support.function" },
 				"1": { "patterns": [ { "include": "#macro" } ], "name": "support.function" }

--- a/syntaxes/qcpu.tmLanguage.json
+++ b/syntaxes/qcpu.tmLanguage.json
@@ -30,7 +30,7 @@
 			"name": "comment"
 		},
 		"assembly": {
-			"match": "\\b(?:ADD|AND|AST|CND|CPL|CPN|CPS|DDS|DEC|DLS|ENT|IMM|IMP|INC|IOR|JMP|MDA|MLD|MMA|MSA|MST|NEG|NOP|NTA|PCM|PLD|POI|PPL|PPS|PST|RSH|RST|SPL|SUB|XOR)\\b",
+			"match": "\\b(?:ADD|AND|AST|CND|CPL|CPN|CPS|DSS|DEC|DLS|ENT|IMM|IMP|INC|IOR|JMP|MDA|MLD|MMA|MSA|MST|NEG|NOP|NTA|PCM|PLD|POI|PPL|PPS|PST|RSH|RST|SPL|SUB|XOR)\\b",
 			"name": "keyword"
 		},
 		"label": {

--- a/syntaxes/qcpu.tmLanguage.json
+++ b/syntaxes/qcpu.tmLanguage.json
@@ -34,7 +34,7 @@
 			"name": "keyword"
 		},
 		"label": {
-			"match": "\\.&?([\\w.@]+)\\b[:!+-]?",
+			"match": "\\.&?([\\w.@]+)\\b[:!+-\*]?",
 			"captures": {
 				"0": { "name": "support.function" },
 				"1": { "patterns": [ { "include": "#macro" } ], "name": "support.function" }


### PR DESCRIPTION
The page `*` addressing mode was added, so something like `.someaddressablepage*` can be done to retrieve the page in the lowest bits (`0b00000xxx`) rather than the full page mode (`0bxxxyyyyy`). The `DSS` instruction was also fixed.