### PR TITLE
Syntax: implement support for `@DROPTHROUGH`

### DIFF
--- a/syntaxes/qcpu.tmLanguage.json
+++ b/syntaxes/qcpu.tmLanguage.json
@@ -179,6 +179,13 @@
 				{ "include": "$self" }
 			]
 		},
+		"DROPTHROUGH": {
+			"match": "(@)(DROPTHROUGH)(?:\\s+([^;]+))?",
+			"captures": {
+				"1": { "name": "keyword.control strong" },
+				"2": { "name": "keyword.control" }
+			}
+		},
 		"DECLARE": {
 			"match": "(@)(DECLARE)(?:\\s+(\\w+)(?:\\s+(\\S+))?)?",
 			"captures": {


### PR DESCRIPTION
Implements the `@DROPTHROUGH <instruction + operand>` keyword, which can only be used in `@IF` (and `@ELSE`) closures. (It transpiles the instruction regardless whether the if-statement passed or not.)

```s
@IF foo
    MLD @bar
    @DROPTHROUGH CND #zero
    JMP .label
@END
// ... CND will always appear
```