### PR TITLE
Syntax: add/remove/rename instructions

### DIFF
--- a/syntaxes/qcpu.tmLanguage.json
+++ b/syntaxes/qcpu.tmLanguage.json
@@ -27,7 +27,7 @@
 			"name": "comment"
 		},
 		"assembly": {
-			"match": "\\b(?i:NOP|PSP|PPL|CPL|CPA|MSA|NTA|PCM|CND|IMM|XCH|RST|AST|INC|DEC|NEG|RSH|ADD|SUB|IOR|AND|XOR|IMP|BSL|BPL|BSR|BPR|ENT|MMU|MDA|PPS|PST|PLD|JMP|CTS|BRH|MST|MLD)\\b",
+			"match": "\\b(?i:NOP|PPI|PPL|CPP|CPL|NTA|PCM|CND|IMM|XCH|PPS|RST|AST|INC|DEC|NEG|RSH|ADD|SUB|IOR|AND|XOR|BSL|BPL|BSR|BPR|ENT|MMU|PRF|PST|PLD|JMP|CAL|BRH|MST|MLD)\\b",
 			"name": "keyword"
 		},
 		"label-address": {


### PR DESCRIPTION
* renames `PSP` (parameters static push) to `PPI` (parameters push immediate);
* adds `CPP` (push pc to call stack);
* removes `CPA` (call stack pull into address) in favour of `CPL` (call stack pull (into pointer));
* removes `MSA` (mmu static arg) due to removal of MMU args;
* removes `MDA` (mmu dynamic arg) due to removal of MMU args;
* adds `PRF` (prefetch data memory);
* renames `CTS` (call to subroutine) to `CAL` (call subroutine).