### PR TITLE
Syntax: organise call stack instructions

### DIFF
--- a/syntaxes/qcpu.tmLanguage.json
+++ b/syntaxes/qcpu.tmLanguage.json
@@ -27,7 +27,7 @@
 			"name": "comment"
 		},
 		"assembly": {
-			"match": "\\b(?i:NOP|PPI|PPL|CPP|CPL|NTA|PCM|CND|IMM|XCH|PPS|RST|AST|INC|DEC|NEG|RSH|ADD|SUB|IOR|AND|XOR|BSL|BPL|BSR|BPR|ENT|MMU|PRF|PST|PLD|JMP|CAL|BRH|MST|MLD)\\b",
+			"match": "\\b(?i:NOP|PPI|PPL|CPS|CPL|CPA|NTA|PCM|CND|IMM|XCH|PPS|RST|AST|INC|DEC|NEG|RSH|ADD|SUB|IOR|AND|XOR|BSL|BPL|BSR|BPR|ENT|MMU|PRF|PST|PLD|JMP|CAL|BRH|MST|MLD)\\b",
 			"name": "keyword"
 		},
 		"label-address": {


### PR DESCRIPTION
* removes `CPP` (call stack push PC + 2);
* re-adds `CPS` (call stack push accumulator);
* renames `CPL` to `CPA` (call stack pull into pointer);
* re-adds `CPL` (call stack pull (into accumulator)).