### PR TITLE
Syntax: update instructions to manipulate call stack

### DIFF
--- a/syntaxes/qcpu.tmLanguage.json
+++ b/syntaxes/qcpu.tmLanguage.json
@@ -27,7 +27,7 @@
 			"name": "comment"
 		},
 		"assembly": {
-			"match": "\\b(?i:NOP|PPI|PPL|CPS|CPL|CPA|NTA|PCM|CND|IMM|XCH|PPS|RST|AST|INC|DEC|NEG|RSH|ADD|SUB|IOR|AND|XOR|BSL|BPL|BSR|BPR|ENT|MMU|PRF|PST|PLD|JMP|CAL|BRH|MST|MLD)\\b",
+			"match": "\\b(?i:NOP|PCM|PPI|PPL|CPS|CPI|CPL|CPA|CND|IMM|XCH|PPS|RST|AST|INC|DEC|NEG|RSH|ADD|SUB|IOR|AND|XOR|BSL|BPL|BSR|BPR|ENT|MMU|PRF|PST|PLD|JMP|CAL|BRH|MST|MLD)\\b",
 			"name": "keyword"
 		},
 		"label-address": {


### PR DESCRIPTION
* removes `NTA` (NOT accumulator);
* adds `CPI` (call stack push immediate);
* moves `PCM` (propagate carry modifier) to 0b001.