### PR TITLE
Syntax: add `MLI` instruction

### DIFF
--- a/syntaxes/qcpu.tmLanguage.json
+++ b/syntaxes/qcpu.tmLanguage.json
@@ -32,7 +32,7 @@
 			"name": "variable.other.constant"
 		},
 		"assembly": {
-			"match": "\\b(?i:PPI|PPL|PPK|CPI|CPL|CPA|NTA|PCM|IMM|PPS|CPS|XCH|RST|AST|INC|DEC|NEG|RSH|ADD|SUB|IOR|AND|XOR|BSL|BPL|BSR|BPR|ENT|MMU|PRF|PST|PLD|JMP|CAL|BRH|MST|MLD)\\b",
+			"match": "\\b(?i:PPI|PPL|PPK|CPI|CPL|CPA|NTA|PCM|IMM|PPS|CPS|XCH|RST|AST|INC|DEC|NEG|RSH|ADD|SUB|IOR|AND|XOR|BSL|BPL|BSR|BPR|ENT|MMU|PRF|PRT|JMP|CAL|BRH|MST|MLD|MLI)\\b",
 			"name": "keyword"
 		},
 		"label-address": {


### PR DESCRIPTION
* adds `MLI` (memory load increment);
* merges `PST` (port store) and `PLD` (port load) into `PRT` (port).